### PR TITLE
Make the build more portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.1-alpine
 
-COPY --link --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN docker-php-ext-install opcache bcmath
 


### PR DESCRIPTION
`COPY --link` seems to be a rather new feature not universally supported